### PR TITLE
ci: Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run load test using action code from commit
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ jobs:
 
     services:
       quickpizza:
-        image: ghcr.io/grafana/quickpizza-local:0.2.0
+        image: ghcr.io/grafana/quickpizza-local:0.4.0
         ports:
           - 3333:3333
           
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4
   
       - name: Run local k6 test
-        uses: grafana/k6-action@v0.2.0
+        uses: grafana/k6-action@v0.3.0
         with:
           filename: script.js
         env:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run k6 local test
         uses: grafana/k6-action@v0.3.0
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run k6 cloud test
         uses: grafana/k6-action@v0.3.0
         with:
@@ -145,7 +145,7 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
   
       - name: Run local k6 test
         uses: grafana/k6-action@v0.2.0
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install k6
         run: |
           curl https://github.com/grafana/k6/releases/download/v0.44.0/k6-v0.44.0-linux-amd64.tar.gz -L | tar xvz --strip-components 1


### PR DESCRIPTION
Hey there,

Just noticed references in the doc and then the action itself using the actions/checkout using v2. Just thought of bumping the version and update documentation. 

Also saw references to the k6-action and quickpizza that could be updated to newer versions and update them on the README. 
Run the action locally (since do not have k6 cloud) in my own fork and it seems it was successful. 

Let me know if is anything missing. Did not find a CONTRIBUTING.md.